### PR TITLE
docs: add issue and pull request templates to .github directory

### DIFF
--- a/docs/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/docs/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report an error or unexpected behavior
+title: "[Bug] "
+labels: ["Bug"]
+assignees: ""
+---
+
+### 🐞 Description of the bug
+(Explain what is going wrong.)
+
+### 🔁 Steps to reproduce
+1. 
+2. 
+3. 
+
+### 📌 Expected behavior
+(What should have happened?)
+
+### 📎 Screenshots / Logs
+(If applicable.)
+
+### 🧩 Environment
+- OS:
+- Branch:
+- .NET version / Browser version:
+
+### 📝 Additional context
+(Anything relevant.)

--- a/docs/.github/ISSUE_TEMPLATE/config.yml
+++ b/docs/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/docs/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/docs/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request / Task
+about: Create a new feature, enhancement, or task
+title: "[Feature] "
+labels: ["Feature"]
+assignees: ""
+---
+
+### 📝 Description
+(Describe what needs to be added or improved.)
+
+### 🎯 Objective
+(What is the expected final outcome?)
+
+### 📋 Acceptance Criteria
+- [ ] 
+- [ ] 
+- [ ] 
+
+### 🔗 Related Areas
+(Backend, Frontend, UI/UX, Documentation, etc.)
+
+### 🧩 Additional Notes
+(Anything important to consider.)

--- a/docs/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/docs/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,18 @@
+# 📦 Pull Request
+
+## 🔍 Description
+(Brief explanation of what was done.)
+
+## 🧩 Main changes
+-
+-
+-
+
+## 🔗 Related Issues
+Closes #
+
+## 🧪 How to test
+(Describe how to verify the changes.)
+
+## ⚠️ Additional Notes
+(Important info, breaking changes, considerations, etc.)


### PR DESCRIPTION
### Summary

This pull request adds standardized issue and pull request templates to the repository.

- Introduces templates for bug reports, feature requests, and general tasks.
- Adds a pull request template to improve code review and collaboration.
- All templates are located in the `.github/ISSUE_TEMPLATE` directory.

### Motivation

These templates will help streamline project management, improve communication, and ensure consistency in reporting issues and submitting pull requests.